### PR TITLE
Auth47 authentication to Soroban

### DIFF
--- a/docker/my-dojo/node/keys.index.js
+++ b/docker/my-dojo/node/keys.index.js
@@ -27,17 +27,30 @@ try {
     console.error(error)
 }
 
+// Retrieve Soroban config from conf files
+let sorobanRpcUrl = null
+let sorobanKeyAuth47 = null
+let sorobanKeyAnnounce = null
+
+if (process.env.SOROBAN_INSTALL === 'on') {
+    sorobanRpcUrl = `http://${process.env.NET_DOJO_SOROBAN_IPV4}:${process.env.SOROBAN_PORT}/rpc`
+    if (bitcoinNetwork === 'bitcoin') {
+        sorobanKeyAnnounce = `${process.env.SOROBAN_ANNOUNCE_KEY_MAIN}`
+        sorobanKeyAuth47 = 'soroban.auth47.mainnet.auth'
+    } else {
+        sorobanKeyAnnounce = `${process.env.SOROBAN_ANNOUNCE_KEY_TEST}`
+        sorobanKeyAuth47 = 'soroban.auth47.testnet.auth'
+    }
+}
+
+
 // Retrieve PandoTx config from conf files
 let pandoTxPushActive = 'inactive'
 let pandoTxProcessActive = 'inactive'
-let pandoTxSorobanUrl = null
 let pandoTxKeyPush = null
 let pandoTxKeyResults = null
-let pandoTxKeyAnnounce = null
 
 if (process.env.SOROBAN_INSTALL === 'on') {
-    pandoTxSorobanUrl = `http://${process.env.NET_DOJO_SOROBAN_IPV4}:${process.env.SOROBAN_PORT}/rpc`
-    
     if (process.env.NODE_PANDOTX_PUSH === 'on') {
         pandoTxPushActive = 'active'
     }
@@ -51,11 +64,9 @@ if (process.env.SOROBAN_INSTALL === 'on') {
     if (bitcoinNetwork === 'bitcoin') {
         pandoTxKeyPush = 'pandotx.mainnet.push'
         pandoTxKeyResults = 'pandotx.mainnet.results'
-        pandoTxKeyAnnounce = `${process.env.SOROBAN_ANNOUNCE_KEY_MAIN}`
     } else {
         pandoTxKeyPush = 'pandotx.testnet.push'
         pandoTxKeyResults = 'pandotx.testnet.results'
-        pandoTxKeyAnnounce = `${process.env.SOROBAN_ANNOUNCE_KEY_TEST}`
     }
 }
 
@@ -281,6 +292,20 @@ export default {
             maxDeltaHeight: Number.parseInt(process.env.NODE_TXS_SCHED_MAX_DELTA_HEIGHT, 10)
         },
         /*
+         * Soroban
+         */
+        soroban: {
+            // Url of the Soroban RPC API used by this node
+            rpc: sorobanRpcUrl,
+            // Use a SOCKS5 proxy for all communications with the Soroban node
+            // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
+            socks5Proxy: `socks5h://${process.env.NET_DOJO_TOR_IPV4}:${process.env.TOR_SOCKS_PORT}`,
+            // Soroban key used to announce public Soroban API endpoints
+            keyAnnounce: sorobanKeyAnnounce,
+            // Soroban key used to announce response to auth47 challenge
+            keyAuth47: sorobanKeyAuth47
+        },
+        /*
          * PandoTx
          */
         pandoTx: {
@@ -290,17 +315,10 @@ export default {
             // Process PandoTx transactions
             // Values: active | inactive
             process: pandoTxProcessActive,
-            // Url of the Soroban RPC API used by this node
-            sorobanUrl: pandoTxSorobanUrl,
-            // Use a SOCKS5 proxy for all communications with the Soroban node
-            // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
-            socks5Proxy: `socks5h://${process.env.NET_DOJO_TOR_IPV4}:${process.env.TOR_SOCKS_PORT}`,
             // Soroban key used for pushed transactions
             keyPush: pandoTxKeyPush,
             // Soroban key used for results of pushes
-            keyResults: pandoTxKeyResults,
-            // Soroban key used to announce public Soroban API endpoints
-            keyAnnounce: pandoTxKeyAnnounce
+            keyResults: pandoTxKeyResults
         },
         /*
          * Tracker

--- a/keys/index-example.js
+++ b/keys/index-example.js
@@ -223,6 +223,20 @@ export default {
             maxDeltaHeight: 18
         },
         /*
+         * Soroban
+         */
+        soroban: {
+            // Url of the Soroban RPC API used by this node
+            rpc: null,
+            // Use a SOCKS5 proxy for all communications with the Soroban node
+            // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
+            socks5Proxy: null,
+            // Soroban key used to announce public Soroban API endpoints
+            keyAnnounce: "soroban.cluster.mainnet.nodes",
+            // Soroban key used to announce response to auth47 challenge
+            keyAuth47: "soroban.auth47.mainnet.auth"
+        },
+        /*
          * PandoTx
          */
         pandoTx: {
@@ -232,17 +246,10 @@ export default {
             // Process PandoTx transactions
             // Values: active | inactive
             process: "inactive",
-            // Url of the Soroban RPC API used by this node
-            sorobanUrl: null,
-            // Use a SOCKS5 proxy for all communications with the Soroban node
-            // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
-            socks5Proxy: null,
             // Soroban key used for pushed transactions
             keyPush: "pandotx.mainnet.push",
             // Soroban key used for results of pushes
-            keyResults: "pandotx.mainnet.results",
-            // Soroban key used to announce public Soroban API endpoints
-            keyAnnounce: "soroban.cluster.mainnet.nodes"
+            keyResults: "pandotx.mainnet.results"
         },
         /*
          * Tracker
@@ -354,14 +361,17 @@ export default {
             maxNbEntries: 10,
             maxDeltaHeight: 18
         },
+        soroban: {
+            rpc: null,
+            socks5Proxy: null,
+            keyAnnounce: "soroban.cluster.testnet.nodes",
+            keyAuth47: "soroban.auth47.testnet.auth"
+        },
         pandoTx: {
             push: "inactive",
             process: "inactive",
-            sorobanUrl: null,
-            socks5Proxy: null,
             keyPush: "pandotx.testnet.push",
-            keyResults: "pandotx.testnet.results",
-            keyAnnounce: "soroban.cluster.testnet.nodes"
+            keyResults: "pandotx.testnet.results"
         },
         tracker: {
             mempoolProcessPeriod: 2000,

--- a/lib/auth/auth-rest-api.js
+++ b/lib/auth/auth-rest-api.js
@@ -12,6 +12,7 @@ import { urlencoded, json } from 'milliparsec'
 // eslint-disable-next-line import/no-unresolved
 import { Auth47Verifier } from '@samouraiwallet/auth47'
 import * as ecc from 'tiny-secp256k1'
+import { RPC } from 'soroban-client-nodejs'
 
 import HttpServer from '../http-server/http-server.js'
 import authentMgr from './authentication-manager.js'
@@ -31,11 +32,15 @@ const keys = keysFile[network.key]
 const adminPaymentCodes = keys.auth.strategies?.auth47?.paymentCodes?.filter(Boolean) ?? [] // filter out falsy values
 const auth47Enabled = adminPaymentCodes.length > 0
 const AUTH47_CALLBACK_URI = '/auth/auth47/authenticate'
+const AUTH47_SOROBAN_CALLBACK_URI = '/auth/auth47/authenticate/soroban'
+
 const TEN_MINUTES = 10 * 60 * 1000
 
 const verifier = auth47Enabled && keys.auth.strategies?.auth47?.hostname
     ? new Auth47Verifier(ecc, `${keys.auth.strategies?.auth47?.hostname}${network.key === 'testnet' ? '/test/v2' : '/v2'}${AUTH47_CALLBACK_URI}`)
     : null
+
+const verifierSoroban = new Auth47Verifier(ecc, `${keys.auth.strategies?.auth47?.hostname}${network.key === 'testnet' ? '/test/v2' : '/v2'}${AUTH47_SOROBAN_CALLBACK_URI}`)
 
 const authCache = new QuickLRU({
     maxSize: 10,
@@ -89,6 +94,12 @@ class AuthRestApi {
             '/auth/auth47/uri',
             this.getAuth47Uri.bind(this)
         )
+        
+        this.httpServer.app.post(
+            AUTH47_SOROBAN_CALLBACK_URI,
+            jsonParser,
+            this.sorobanAuthenticateAuth47.bind(this)
+        )
 
         this.httpServer.app.post(
             AUTH47_CALLBACK_URI,
@@ -102,6 +113,23 @@ class AuthRestApi {
         )
 
         this.initIpc()
+        this.initSorobanRpc()
+    }
+
+
+    /**
+     * Initialize a wrapper to the Soroban RPC API is configuration is set
+     * @returns {Promise<void>}
+     */
+    initSorobanRpc() {
+        this.sorobanRpc = null
+        const sorobanUrl = keys['soroban']['rpc']
+        if (sorobanUrl != null) {
+            const socks5ProxyUrl = (sorobanUrl.includes('.onion')) ?
+                keys['soroban']['socks5Proxy'] :
+                null
+            this.sorobanRpc = new RPC(sorobanUrl, socks5ProxyUrl)
+        }
     }
 
     /**
@@ -222,6 +250,42 @@ class AuthRestApi {
             }
         } else {
             HttpServer.sendError(res, 'Auth47 not enabled')
+        }
+    }
+
+    /**
+     * Authenticate to Soroban with Auth47 
+     * @param {Request} req - http request object
+     * @param {Response} res - http response object
+     */
+    async sorobanAuthenticateAuth47(req, res) {
+        if (!this.sorobanRpc) {
+            HttpServer.sendAuthError(res, 'soroban network is unreachable from this dojo')
+            return
+        }
+
+        if (!verifierSoroban) {
+            HttpServer.sendError(res, 'Auth47 not enabled')
+            return
+        }
+
+        const verifyResult = verifierSoroban.verifyProof(req.body, network.key)
+        if (verifyResult.result !== 'ok') {
+            HttpServer.sendAuthError(res, verifyResult.error)
+            return
+        }
+
+        const entry = JSON.stringify(req.body)
+        const success = await this.sorobanRpc.directoryAdd(
+            keys['soroban']['keyAuth47'], 
+            entry, 
+            'short'
+        )
+        if (success) {
+            Logger.info('Successful authentication to Soroban with auth47')
+            HttpServer.sendOk(res)
+        } else {
+            HttpServer.sendAuthError(res, 'failed to push proof over the Soroban network')
         }
     }
 

--- a/lib/soroban/util.js
+++ b/lib/soroban/util.js
@@ -23,9 +23,9 @@ const SorobanUtil = {
         const keys = keysFile[network.key]
         let sorobanRpc = null
         try {
-            const sorobanUrl = keys['pandoTx']['sorobanUrl']
+            const sorobanUrl = keys['soroban']['rpc']
             const socks5ProxyUrl = (sorobanUrl.includes('.onion')) ?
-                keys['pandoTx']['socks5Proxy'] :
+                keys['soroban']['socks5Proxy'] :
                 null
             sorobanRpc = new RPC(sorobanUrl, socks5ProxyUrl)
             const entries = await sorobanRpc.directoryList('test.start')

--- a/pushtx/pandotx-emitter.js
+++ b/pushtx/pandotx-emitter.js
@@ -28,10 +28,10 @@ class PandoTxEmitter {
         // Retrieve a few useful keys
         this.keyPush = keys['pandoTx']['keyPush']
         this.keyResults = keys['pandoTx']['keyResults']
-        this.keyAnnounce = keys['pandoTx']['keyAnnounce']
-        this.keySocks5Proxy = keys['pandoTx']['socks5Proxy']
+        this.keyAnnounce = keys['soroban']['keyAnnounce']
+        this.keySocks5Proxy = keys['soroban']['socks5Proxy']
         // Initialize a Soroban RPC client
-        const sorobanUrl = keys['pandoTx']['sorobanUrl']
+        const sorobanUrl = keys['soroban']['rpc']
         const socks5ProxyUrl = (sorobanUrl.includes('.onion')) ?
             this.keySocks5Proxy :
             null

--- a/pushtx/pandotx-processor.js
+++ b/pushtx/pandotx-processor.js
@@ -33,9 +33,9 @@ class PandoTxProcessor {
         this.keyPush = keys['pandoTx']['keyPush']
         this.keyResults = keys['pandoTx']['keyResults']
 
-        const sorobanUrl = keys['pandoTx']['sorobanUrl']
+        const sorobanUrl = keys['soroban']['rpc']
         const socks5ProxyUrl = (sorobanUrl.includes('.onion')) ?
-            keys['pandoTx']['socks5Proxy'] :
+            keys['soroban']['socks5Proxy'] :
             null
         this.sorobanRpc = new RPC(sorobanUrl, socks5ProxyUrl)
 


### PR DESCRIPTION
Authenticate to Soroban with auth47 through a new REST API endpoint acting as a gateway.