### PR TITLE
Add a fallback mechanism to pandotx

### DIFF
--- a/docker/my-dojo/conf/docker-node.conf.tpl
+++ b/docker/my-dojo/conf/docker-node.conf.tpl
@@ -42,4 +42,8 @@ NODE_PANDOTX_PUSH=off
 # Value: on | off
 NODE_PANDOTX_PROCESS=on
 
+# Max number of retries in case of a failed push
+# Type: numeric
+NODE_PANDOTX_NB_RETRIES=2
+
 

--- a/docker/my-dojo/node/keys.index.js
+++ b/docker/my-dojo/node/keys.index.js
@@ -49,10 +49,12 @@ let pandoTxPushActive = 'inactive'
 let pandoTxProcessActive = 'inactive'
 let pandoTxKeyPush = null
 let pandoTxKeyResults = null
+let pandoTxNbRetries = 2
 
 if (process.env.SOROBAN_INSTALL === 'on') {
     if (process.env.NODE_PANDOTX_PUSH === 'on') {
         pandoTxPushActive = 'active'
+        pandoTxNbRetries = Number.parseInt(process.env.NODE_PANDOTX_NB_RETRIES, 10)
     }
 
     if (process.env.SOROBAN_ANNOUNCE === 'on') {
@@ -318,7 +320,9 @@ export default {
             // Soroban key used for pushed transactions
             keyPush: pandoTxKeyPush,
             // Soroban key used for results of pushes
-            keyResults: pandoTxKeyResults
+            keyResults: pandoTxKeyResults,
+            // Max number of retries after a failed push
+            nbRetries: pandoTxNbRetries
         },
         /*
          * Tracker

--- a/keys/index-example.js
+++ b/keys/index-example.js
@@ -249,7 +249,9 @@ export default {
             // Soroban key used for pushed transactions
             keyPush: "pandotx.mainnet.push",
             // Soroban key used for results of pushes
-            keyResults: "pandotx.mainnet.results"
+            keyResults: "pandotx.mainnet.results",
+            // Max number of retries after a failed push
+            nbRetries: 2
         },
         /*
          * Tracker
@@ -371,7 +373,8 @@ export default {
             push: "inactive",
             process: "inactive",
             keyPush: "pandotx.testnet.push",
-            keyResults: "pandotx.testnet.results"
+            keyResults: "pandotx.testnet.results",
+            nbRetries: 2
         },
         tracker: {
             mempoolProcessPeriod: 2000,

--- a/lib/util.js
+++ b/lib/util.js
@@ -403,6 +403,21 @@ const Util = {
      * 1Mb in bytes
      */
     MB: 1024 * 1024,
+    /**
+     * @description Return a random integer from a given range
+     * @param {number} min
+     * @param {number} max
+     * @returns {number}
+     */
+    secureGetRandomInt(min, max) {       
+        let byteArray = new Uint8Array(1)
+        crypto.getRandomValues(byteArray)
+        const range = max - min + 1
+        const max_range = 256
+        if (byteArray[0] >= Math.floor(max_range / range) * range)
+            return secureGetRandomInt(min, max)
+        return min + (byteArray[0] % range)
+    }
 }
 
 

--- a/pushtx/pushtx-processor.js
+++ b/pushtx/pushtx-processor.js
@@ -141,12 +141,19 @@ class PushTxProcessor {
         // At this point, the raw hex parses as a legitimate transaction.
         let txid = null
         try {
+            let processLocalPush = true
+            // Attempt to send via PandoTx (Soroban)
             if ((keys['pandoTx']['push'] === 'active') && !forceLocalPush) {
-                // Attempt to send via PandoTx (Soroban)
-                txid = await this.pandoTxEmitter.emit(rawtx)
-                Logger.info(`PandoTx : Pushed!`)
-            } else {
-                // Attempt to send via RPC to the bitcoind instance
+                try {
+                    txid = await this.pandoTxEmitter.emit(rawtx)
+                    Logger.info(`PandoTx : Pushed!`)
+                    processLocalPush = false
+                } catch (e) {
+                    Logger.error(e.message ? e.message : e, 'PandoTx : ')
+                }
+            }
+            // Attempt to send via RPC to the bitcoind instance 
+            if (processLocalPush) {
                 txid = await this.rpcClient.sendrawtransaction({ hexstring: rawtx })
                 Logger.info('PushTx : Pushed!')
             }


### PR DESCRIPTION
- Add an new config option allowing to define the number of attempts tried by PandoTx in case of failures caused by remote nodes.
- Push is now done through the local Soroban node with a probability of 1/(nb_retries+1) and through a remote Soroban node with a probability of 1-1/(nb_retries+1)
- If all attempts have failed, push is done directly through the local bitcoind (worst case scenario)