### PR TITLE
Add a fallback mechanism to pandotx

### DIFF
--- a/docker/my-dojo/conf/docker-node.conf.tpl
+++ b/docker/my-dojo/conf/docker-node.conf.tpl
@@ -42,6 +42,15 @@ NODE_PANDOTX_PUSH=off
 # Value: on | off
 NODE_PANDOTX_PROCESS=on
 
+# Fallback mode
+# Has effect only if NODE_PANDOTX_PUSH=on
+# In convenient mode, a push will ultimately be processed 
+#   through the local node (soroban or bitcoind) in case of an active attack
+# In secure mode, it will fail if it can't be processed through 
+#   a randomnly selected Soroban node 
+# Value: secure | convenient
+NODE_PANDOTX_FALLBACK_MODE=convenient
+
 # Max number of retries in case of a failed push
 # Type: numeric
 NODE_PANDOTX_NB_RETRIES=2

--- a/docker/my-dojo/conf/docker-node.conf.tpl
+++ b/docker/my-dojo/conf/docker-node.conf.tpl
@@ -42,4 +42,8 @@ NODE_PANDOTX_PUSH=off
 # Value: on | off
 NODE_PANDOTX_PROCESS=on
 
+# Max number of retries in case of a failed push
+# Type: numeric
+NODE_PANDOTX_NB_RETRIES=2
+
 

--- a/docker/my-dojo/node/keys.index.js
+++ b/docker/my-dojo/node/keys.index.js
@@ -49,10 +49,12 @@ let pandoTxPushActive = 'inactive'
 let pandoTxProcessActive = 'inactive'
 let pandoTxKeyPush = null
 let pandoTxKeyResults = null
+let pandoTxNbRetries = 2
 
 if (process.env.SOROBAN_INSTALL === 'on') {
     if (process.env.NODE_PANDOTX_PUSH === 'on') {
         pandoTxPushActive = 'active'
+        pandoTxNbRetries = Number.parseInt(process.env.NODE_PANDOTX_NB_RETRIES, 10)
     }
 
     if (process.env.SOROBAN_ANNOUNCE === 'on') {
@@ -318,7 +320,9 @@ export default {
             // Soroban key used for pushed transactions
             keyPush: pandoTxKeyPush,
             // Soroban key used for results of pushes
-            keyResults: pandoTxKeyResults
+            keyResults: pandoTxKeyResults,
+            // Max number of retries after a failed push
+            nbRetries: pandoTxNbRetries
         },
         /*
          * Tracker

--- a/docker/my-dojo/node/keys.index.js
+++ b/docker/my-dojo/node/keys.index.js
@@ -50,10 +50,12 @@ let pandoTxProcessActive = 'inactive'
 let pandoTxKeyPush = null
 let pandoTxKeyResults = null
 let pandoTxNbRetries = 2
+let pandoTxFallbackMode = null
 
 if (process.env.SOROBAN_INSTALL === 'on') {
     if (process.env.NODE_PANDOTX_PUSH === 'on') {
         pandoTxPushActive = 'active'
+        pandoTxFallbackMode = process.env.NODE_PANDOTX_FALLBACK_MODE
         pandoTxNbRetries = Number.parseInt(process.env.NODE_PANDOTX_NB_RETRIES, 10)
     }
 
@@ -321,6 +323,9 @@ export default {
             keyPush: pandoTxKeyPush,
             // Soroban key used for results of pushes
             keyResults: pandoTxKeyResults,
+            // Fallback mode
+            // Values: secure | convenient
+            fallbackMode: pandoTxFallbackMode,
             // Max number of retries after a failed push
             nbRetries: pandoTxNbRetries
         },

--- a/keys/index-example.js
+++ b/keys/index-example.js
@@ -250,6 +250,9 @@ export default {
             keyPush: "pandotx.mainnet.push",
             // Soroban key used for results of pushes
             keyResults: "pandotx.mainnet.results",
+            // Fallback mode
+            // Values: secure | convenient
+            fallbackMode: "convenient",
             // Max number of retries after a failed push
             nbRetries: 2
         },
@@ -374,6 +377,7 @@ export default {
             process: "inactive",
             keyPush: "pandotx.testnet.push",
             keyResults: "pandotx.testnet.results",
+            fallbackMode: "convenient",
             nbRetries: 2
         },
         tracker: {

--- a/keys/index-example.js
+++ b/keys/index-example.js
@@ -249,7 +249,9 @@ export default {
             // Soroban key used for pushed transactions
             keyPush: "pandotx.mainnet.push",
             // Soroban key used for results of pushes
-            keyResults: "pandotx.mainnet.results"
+            keyResults: "pandotx.mainnet.results",
+            // Max number of retries after a failed push
+            nbRetries: 2
         },
         /*
          * Tracker
@@ -371,7 +373,8 @@ export default {
             push: "inactive",
             process: "inactive",
             keyPush: "pandotx.testnet.push",
-            keyResults: "pandotx.testnet.results"
+            keyResults: "pandotx.testnet.results",
+            nbRetries: 2
         },
         tracker: {
             mempoolProcessPeriod: 2000,

--- a/lib/util.js
+++ b/lib/util.js
@@ -403,21 +403,6 @@ const Util = {
      * 1Mb in bytes
      */
     MB: 1024 * 1024,
-    /**
-     * @description Return a random integer from a given range
-     * @param {number} min
-     * @param {number} max
-     * @returns {number}
-     */
-    secureGetRandomInt(min, max) {       
-        let byteArray = new Uint8Array(1)
-        crypto.getRandomValues(byteArray)
-        const range = max - min + 1
-        const max_range = 256
-        if (byteArray[0] >= Math.floor(max_range / range) * range)
-            return secureGetRandomInt(min, max)
-        return min + (byteArray[0] % range)
-    }
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -403,6 +403,21 @@ const Util = {
      * 1Mb in bytes
      */
     MB: 1024 * 1024,
+    /**
+     * @description Return a random integer from a given range
+     * @param {number} min
+     * @param {number} max
+     * @returns {number}
+     */
+    secureGetRandomInt(min, max) {       
+        let byteArray = new Uint8Array(1)
+        crypto.getRandomValues(byteArray)
+        const range = max - min + 1
+        const max_range = 256
+        if (byteArray[0] >= Math.floor(max_range / range) * range)
+            return secureGetRandomInt(min, max)
+        return min + (byteArray[0] % range)
+    }
 }
 
 

--- a/pushtx/pandotx-emitter.js
+++ b/pushtx/pandotx-emitter.js
@@ -31,6 +31,7 @@ class PandoTxEmitter {
         this.keyAnnounce = keys['soroban']['keyAnnounce']
         this.keySocks5Proxy = keys['soroban']['socks5Proxy']
         this.maxNbAttempts = keys['pandoTx']['nbRetries'] + 1
+        this.fallbackMode = keys['pandoTx']['fallbackMode']
         // Initialize a Soroban RPC client
         const sorobanUrl = keys['soroban']['rpc']
         const socks5ProxyUrl = (sorobanUrl.includes('.onion')) ?
@@ -133,7 +134,7 @@ class PandoTxEmitter {
             let addedToDirectory = true
             try {
                 // Last attempt: push on local soroban node
-                if (counter == 0) {
+                if (counter == 0 && this.fallbackMode !== 'secure') {
                     // Local push
                     await this.sorobanRpc.directoryAdd(this.keyPush, rawtx, 'fast')
                 } else {

--- a/pushtx/pandotx-emitter.js
+++ b/pushtx/pandotx-emitter.js
@@ -132,8 +132,8 @@ class PandoTxEmitter {
             // Push the transaction over PandoTx
             let addedToDirectory = true
             try {
-                // Push on local soroban node with a probability of 1 / maxNbAttempts
-                if (util.secureGetRandomInt(0, this.maxNbAttempts) == 0) {
+                // Last attempt: push on local soroban node
+                if (counter == 0) {
                     // Local push
                     await this.sorobanRpc.directoryAdd(this.keyPush, rawtx, 'fast')
                 } else {

--- a/pushtx/pushtx-processor.js
+++ b/pushtx/pushtx-processor.js
@@ -141,12 +141,19 @@ class PushTxProcessor {
         // At this point, the raw hex parses as a legitimate transaction.
         let txid = null
         try {
+            let processLocalPush = true
+            // Attempt to send via PandoTx (Soroban)
             if ((keys['pandoTx']['push'] === 'active') && !forceLocalPush) {
-                // Attempt to send via PandoTx (Soroban)
-                txid = await this.pandoTxEmitter.emit(rawtx)
-                Logger.info(`PandoTx : Pushed!`)
-            } else {
-                // Attempt to send via RPC to the bitcoind instance
+                try {
+                    txid = await this.pandoTxEmitter.emit(rawtx)
+                    Logger.info(`PandoTx : Pushed!`)
+                    processLocalPush = false
+                } catch (e) {
+                    Logger.error(e.message ? e.message : e, 'PandoTx : ')
+                }
+            }
+            // Attempt to send via RPC to the bitcoind instance 
+            if (processLocalPush) {
                 txid = await this.rpcClient.sendrawtransaction({ hexstring: rawtx })
                 Logger.info('PushTx : Pushed!')
             }

--- a/pushtx/pushtx-processor.js
+++ b/pushtx/pushtx-processor.js
@@ -150,6 +150,9 @@ class PushTxProcessor {
                     processLocalPush = false
                 } catch (e) {
                     Logger.error(e.message ? e.message : e, 'PandoTx : ')
+                    if (keys['pandoTx']['fallbackMode'] === 'secure') {
+                        processLocalPush = false
+                    }
                 }
             }
             // Attempt to send via RPC to the bitcoind instance 


### PR DESCRIPTION
New fallback mechanism replacing the first proposal (see #8) and providing a better tradeoff against a passive/active adversary.

- Add an new config option allowing to define the number of attempts tried by PandoTx in case of failures caused by remote nodes.
- Add a new config option defining the fallback mode after _nb_retries_ failures with randomly selected remote Soroban nodes:
   * secure:  push is abandoned if a last attempt fails. An error is returned to the wallet.
   * convenient: a last attempt is done with the local Soroban node. If it fails then transaction is pushed through the local bitcoind.


