### PR TITLE
Add new /support/services RPC endpoint

### DIFF
--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -364,7 +364,7 @@ class SupportRestApi {
                     keyAuth47: keys.soroban.keyAuth47
                 })
             }
-            HttpServer.sendRawData(res, JSON.stringify(returnValue, null, 2))
+            HttpServer.sendOkDataOnly(res, returnValue)
         } catch (error) {
             const returnValue = {
                 status: 'error'

--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -338,7 +338,7 @@ class SupportRestApi {
     /**
      * Get pairing info for miscellaneous services provided by the dojo
      */
-    async getServices(req, res) {
+    getServices(req, res) {
         try {
             const returnValue = { services: [] }
             if (keys.explorer.active !== null) {

--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -83,6 +83,12 @@ class SupportRestApi {
             authMgr.checkHasAdminProfile.bind(authMgr),
             this.getPairing.bind(this),
         )
+
+        this.httpServer.app.get(
+            `/${keys.prefixes.support}/services`,
+            authMgr.checkAuthentication.bind(authMgr),
+            this.getServices.bind(this),
+        )
     }
 
     /**
@@ -328,6 +334,44 @@ class SupportRestApi {
             debugApi && Logger.info('API : Completed GET /pairing/explorer')
         }
     }
+
+    /**
+     * Get pairing info for miscellaneous services provided by the dojo
+     */
+    async getServices(req, res) {
+        try {
+            const returnValue = {
+                services: [{
+                    type: `explorer.${keys.explorer.active}`,
+                    url: keys.explorer.uri
+                }]
+            }
+            if (keys.indexer.active == 'local_indexer' && keys.indexer.localIndexer.externalUri !== null) {
+                returnValue.services.push({
+                    type: `indexer.fullcrum`,
+                    url: keys.indexer.localIndexer.externalUri
+                })
+            }
+            if (keys.soroban.externalRpc !== null) {
+                returnValue.services.push({
+                    type: `soroban.rpc`,
+                    url: keys.soroban.externalRpc,
+                    keyAnnounce: keys.soroban.keyAnnounce,
+                    keyAuth47: keys.soroban.keyAuth47
+                })
+            }
+            HttpServer.sendRawData(res, JSON.stringify(returnValue, null, 2))
+        } catch (error) {
+            const returnValue = {
+                status: 'error'
+            }
+            Logger.error(error, 'API : SupportRestApi.getServices() : Error')
+            HttpServer.sendError(res, JSON.stringify(returnValue, null, 2))
+        } finally {
+            debugApi && Logger.info('API : Completed GET /services')
+        }
+    }
+
 
     /**
      * Validate arguments related to GET xpub info requests

--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -342,19 +342,22 @@ class SupportRestApi {
         try {
             const returnValue = {
                 services: [{
-                    type: `explorer.${keys.explorer.active}`,
+                    type: `explorer`,
+                    kind: keys.explorer.active,
                     url: keys.explorer.uri
                 }]
             }
             if (keys.indexer.active == 'local_indexer' && keys.indexer.localIndexer.externalUri !== null) {
                 returnValue.services.push({
-                    type: `indexer.fullcrum`,
+                    type: `indexer`,
+                    kind: `fullcrum`,
                     url: keys.indexer.localIndexer.externalUri
                 })
             }
             if (keys.soroban.externalRpc !== null) {
                 returnValue.services.push({
-                    type: `soroban.rpc`,
+                    type: `soroban`,
+                    kind: `rpc`,
                     url: keys.soroban.externalRpc,
                     keyAnnounce: keys.soroban.keyAnnounce,
                     keyAuth47: keys.soroban.keyAuth47

--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -351,7 +351,7 @@ class SupportRestApi {
             if (keys.indexer.active == 'local_indexer' && keys.indexer.localIndexer.externalUri !== null) {
                 returnValue.services.push({
                     type: `indexer`,
-                    kind: `fullcrum`,
+                    kind: keys.indexer.localIndexer.type,
                     url: keys.indexer.localIndexer.externalUri
                 })
             }

--- a/accounts/support-rest-api.js
+++ b/accounts/support-rest-api.js
@@ -340,12 +340,13 @@ class SupportRestApi {
      */
     async getServices(req, res) {
         try {
-            const returnValue = {
-                services: [{
+            const returnValue = { services: [] }
+            if (keys.explorer.active !== null) {
+                returnValue.services.push({
                     type: `explorer`,
                     kind: keys.explorer.active,
                     url: keys.explorer.uri
-                }]
+                })
             }
             if (keys.indexer.active == 'local_indexer' && keys.indexer.localIndexer.externalUri !== null) {
                 returnValue.services.push({

--- a/doc/GET_support_services.md
+++ b/doc/GET_support_services.md
@@ -48,7 +48,7 @@ Each service provided by the Dojo has a corresponding entry in the list.
 Each entry in the list is at least composed of:
 * a **type** attribute identifying the service,
 * a **kind** attribute identifying kind of the service,
-* an **url** attribute storing information allowing to access the service.
+* a **url** attribute storing information allowing to access the service.
 
 
 #### Additional attributes

--- a/doc/GET_support_services.md
+++ b/doc/GET_support_services.md
@@ -23,15 +23,18 @@ Status code 200 with JSON response:
 {
   "services": [
     {
-      "type": "explorer.btc_rpc_explorer",
+      "type": "explorer",
+      "kind": "btc_rpc_explorer",
       "url": "http://[...].onion"
     },
     {
-      "type": "indexer.fullcrum",
+      "type": "indexer",
+      "kind": "fullcrum",
       "url": "tcp://[...].onion:50001"
     },
     {
-      "type": "soroban.rpc",
+      "type": "soroban",
+      "kind": "rpc",
       "url": "http://[...].onion/rpc",
       "keyAnnounce": "soroban.cluster.testnet.nodes",
       "keyAuth47": "soroban.auth47.testnet.auth"

--- a/doc/GET_support_services.md
+++ b/doc/GET_support_services.md
@@ -29,7 +29,7 @@ Status code 200 with JSON response:
     },
     {
       "type": "indexer",
-      "kind": "fullcrum",
+      "kind": "fulcrum",
       "url": "tcp://[...].onion:50001"
     },
     {

--- a/doc/GET_support_services.md
+++ b/doc/GET_support_services.md
@@ -1,0 +1,64 @@
+# Get information about public services provided by the Dojo
+
+Get a list of public services provided by the Dojo with pairing information provided for each available service.
+
+
+```http request
+GET /support/services
+```
+
+## Parameters
+* **at** - `string` (optional) - Access Token (json web token). Required if authentication is activated. Alternatively, the access token can be passed through the `Authorization` HTTP header (with the `Bearer` scheme).
+
+
+### Examples
+
+```http request
+GET /support/services
+```
+
+#### Success
+Status code 200 with JSON response:
+```json
+{
+  "services": [
+    {
+      "type": "explorer.btc_rpc_explorer",
+      "url": "http://[...].onion"
+    },
+    {
+      "type": "indexer.fullcrum",
+      "url": "tcp://[...].onion:50001"
+    },
+    {
+      "type": "soroban.rpc",
+      "url": "http://[...].onion/rpc",
+      "keyAnnounce": "soroban.cluster.testnet.nodes",
+      "keyAuth47": "soroban.auth47.testnet.auth"
+    }
+  ]
+}
+```
+
+Each service provided by the Dojo has a corresponding entry in the list.
+
+Each entry in the list is at least composed of:
+* a **type** attribute identifying the service,
+* an **url** attribute storing information allowing to access the service.
+
+
+#### Additional attributes
+
+##### Soroban RPC service
+* keyAnnounce: key identifying the Soroban channel used to announce the onion addresses of Soroban public RPC nodes.
+* keyAuth47: key identifying the Soroban channel used to publish authentication information to Soroban
+
+
+#### Failure
+Status code 400 with JSON response:
+```json
+{
+  "status": "error",
+  "error": "<error message>"
+}
+```

--- a/doc/GET_support_services.md
+++ b/doc/GET_support_services.md
@@ -47,6 +47,7 @@ Each service provided by the Dojo has a corresponding entry in the list.
 
 Each entry in the list is at least composed of:
 * a **type** attribute identifying the service,
+* a **kind** attribute identifying kind of the service,
 * an **url** attribute storing information allowing to access the service.
 
 

--- a/docker/my-dojo/node/keys.index.js
+++ b/docker/my-dojo/node/keys.index.js
@@ -11,8 +11,8 @@ const bitcoinNetwork = (process.env.COMMON_BTC_NETWORK === 'testnet')
     : 'bitcoin'
 
 // Retrieve explorer config from conf files
-let explorerActive = 'oxt'
-let explorerUrl = 'https://oxt.me'
+let explorerActive = null
+let explorerUrl = null
 let auth47Hostname = ''
 if (process.env.EXPLORER_INSTALL === 'on') {
     try {

--- a/keys/index-example.js
+++ b/keys/index-example.js
@@ -165,6 +165,9 @@ export default {
             active: 'local_bitcoind',
             // Local indexer
             localIndexer: {
+                // Name of the installed indexer
+                // Values: null | addrindexrs | fulcrum
+                type: null,
                 // IP address or hostname
                 host: '127.0.0.1',
                 // Port
@@ -173,7 +176,9 @@ export default {
                 // Values: active | inactive
                 batchRequests: 'inactive',
                 // Protocol for communication (TCP or TLS)
-                protocol: 'tcp'
+                protocol: 'tcp',
+                // External URI (if exposed fullcrum)
+                externalUri: null
             },
             // Use a SOCKS5 proxy for all communications with external services
             // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
@@ -228,6 +233,8 @@ export default {
         soroban: {
             // Url of the Soroban RPC API used by this node
             rpc: null,
+            // External url of the Soroban RPC API
+            externalRpc: null,
             // Use a SOCKS5 proxy for all communications with the Soroban node
             // Values: null if no socks5 proxy used, otherwise the url of the socks5 proxy
             socks5Proxy: null,
@@ -343,10 +350,12 @@ export default {
         indexer: {
             active: 'third_party_explorer',
             localIndexer: {
+                type: null,
                 host: '127.0.0.1',
                 port: 50001,
                 batchRequests: 'inactive',
-                protocol: 'tcp'
+                protocol: 'tcp',
+                externalUri: null
             },
             socks5Proxy: null,
             esplora: 'https://blockstream.info/testnet'
@@ -368,6 +377,7 @@ export default {
         },
         soroban: {
             rpc: null,
+            externalRpc: null,
             socks5Proxy: null,
             keyAnnounce: "soroban.cluster.testnet.nodes",
             keyAuth47: "soroban.auth47.testnet.auth"


### PR DESCRIPTION
See the [doc](https://github.com/LaurentMT/samourai-dojo/blob/f89e31301bb67ba80225da3d5c9efd0b0949713b/doc/GET_support_services.md) for all details about the new API endpoint.

Note: The **explorer** attribute returned in the response of the /support/pairing endpoint should be considered deprecated and should be removed in an upcoming version. It might be a good idea to signal its deprecated status in the release notes of the upcoming versions of Dojo (there's no documentation existing for the pairing endpoint). 