### PR TITLE
Update ban-knots script to check service flag 26 (NODE_KNOTS0 for when user agent is hidden

### DIFF
--- a/docker/my-dojo/bitcoin/ban-knots.sh
+++ b/docker/my-dojo/bitcoin/ban-knots.sh
@@ -2,7 +2,7 @@
 
 echo "Running ban script"
 
-# Get all Knots nodes
+# Get all Knots nodes (by user agent or service flag 26)
 ALL_KNOTS=$(bitcoin-cli \
   -rpcconnect="$NET_DOJO_BITCOIND_IPV4" \
   --rpcport="$BITCOIND_RPC_PORT" \
@@ -10,17 +10,26 @@ ALL_KNOTS=$(bitcoin-cli \
   --rpcpassword="$BITCOIND_RPC_PASSWORD" \
   getpeerinfo | \
   jq --raw-output \
-  '.[] | select(.subver | contains("Knots")) | {addr: .addr, id: .id}'
+  '.[] | 
+  select((.subver | contains("Knots")) or ((.services // 0) | . / 67108864 | floor | . % 2 == 1)) | 
+  {
+    addr: .addr, 
+    id: .id, 
+    subver: .subver,
+    detected_by: (if (.subver | contains("Knots")) then "user-agent" else "service-flag-26" end)
+  }'
 )
 
 # Iterate over all Knots nodes
 echo "$ALL_KNOTS" | jq -c '.' | while read -r node; do
   addr=$(echo "$node" | jq -r '.addr')
   id=$(echo "$node" | jq -r '.id')
+  subver=$(echo "$node" | jq -r '.subver')
+  detected_by=$(echo "$node" | jq -r '.detected_by')
   base_addr=$(echo "$addr" | grep -oP '^[^:]+')
 
   if [[ "$addr" == *"$NET_DOJO_TOR_IPV4"* ]]; then
-    echo "Disconnecting node with addr: $addr"
+    echo "Disconnecting Knots node: $addr ($subver) [detected by: $detected_by]"
     bitcoin-cli \
       -rpcconnect="$NET_DOJO_BITCOIND_IPV4" \
       --rpcport="$BITCOIND_RPC_PORT" \
@@ -28,7 +37,7 @@ echo "$ALL_KNOTS" | jq -c '.' | while read -r node; do
       --rpcpassword="$BITCOIND_RPC_PASSWORD" \
       disconnectnode "" "$id"
   else
-    echo "Banning node with addr: $addr"
+    echo "Banning Knots node: $addr ($subver) [detected by: $detected_by]"
     bitcoin-cli \
       -rpcconnect="$NET_DOJO_BITCOIND_IPV4" \
       --rpcport="$BITCOIND_RPC_PORT" \


### PR DESCRIPTION
# Add Service Flag 26 Detection to ban-knots.sh

## Summary
This PR enhances the ban-knots script to detect Bitcoin Knots nodes that attempt to hide by changing their user agent. It now checks for service flag 26 (NODE_KNOTS) in addition to the user agent string.

## What's Changed
- Added detection of service flag 26 (NODE_KNOTS) 
- Enhanced logging to show detection method (user-agent vs service-flag-26)
- Now catches "hidden" Knots nodes that disguise their user agent

## Technical Details
The script now uses this jq filter:
```bash
select((.subver | contains("Knots")) or ((.services // 0) | . / 67108864 | floor | . % 2 == 1))
```

This checks if:
1. The user agent contains "Knots" (existing behavior)
2. OR service flag bit 26 is set (new behavior)

The bitwise check `services / 2^26 | floor | % 2` is mathematically equivalent to `services & (1 << 26)`.

- Uses standard bitwise flag checking
- Is compatible with Bitcoin Core's **getpeerinfo** output format

## Example Output
```
Banning Knots node: 1.2.3.4:8333 (/bitcoinknots:27.0/) [detected by: user-agent]
Banning Knots node: 5.6.7.8:8333 (/Satoshi:27.0/) [detected by: service-flag-26]
```

The enhanced logging shows:
- Which nodes are being banned
- Their reported user agent 
- How they were detected

## Why This Matters
Some Knots nodes change their user agent to evade detection. However, they still advertise service flag 26 (NODE_KNOTS) which allows us to identify them. This makes the ban script more robust against evasion attempts.

According to the Bitcoin network protocol, flag 26 is designated as NODE_KNOTS, making this a reliable detection method.

## Credits
Service flag detection inspired by [gnoban](https://github.com/caesrcd/gnoban) which uses the same flag checking approach.