### PR TITLE
Fix host extraction for ipv6

### DIFF
--- a/docker/my-dojo/bitcoin/ban-knots.sh
+++ b/docker/my-dojo/bitcoin/ban-knots.sh
@@ -17,7 +17,7 @@ ALL_KNOTS=$(bitcoin-cli \
 echo "$ALL_KNOTS" | jq -c '.' | while read -r node; do
   addr=$(echo "$node" | jq -r '.addr')
   id=$(echo "$node" | jq -r '.id')
-  base_addr=$(echo "$addr" | grep -oP '^[^:]+')
+  base_addr=${addr%:*}
 
   if [[ "$addr" == *"$NET_DOJO_TOR_IPV4"* ]]; then
     echo "Disconnecting node with addr: $addr"


### PR DESCRIPTION
Current version is not working for ipv6 addresses because it's removing everything after the first colon.
For example, `[2a02:1210:4a25:2f00:b367:a9cd:3be5:f04c]:8333` becomes `[2a02` and `setban` fails.

Changing to a bash parameter expansion that removes everything after the **last** colon.