### PR TITLE
Fix esplora ntx double-count on paginated address scans

### DIFF
--- a/lib/remote-importer/esplora-wrapper.js
+++ b/lib/remote-importer/esplora-wrapper.js
@@ -92,7 +92,7 @@ class EsploraWrapper extends Wrapper {
 				return returnValue;
 
 			returnValue.txids = [...returnValue.txids, ...txids];
-			returnValue.ntx += returnValue.txids.length;
+			returnValue.ntx += txids.length;
 
 			if (txids.length < EsploraWrapper.NB_TXS_PER_PAGE) {
 				// we have all the transactions


### PR DESCRIPTION
`EsploraWrapper.getAddress()` paginates address history, then incremented `ntx` by the cumulative `txids` length instead of the current page. With `filterAddr` enabled, that could exceed `addrFilterThreshold` (default 1000) while the unique transaction count was still well below the cap. The address was still created, but with an empty `txids` list — no history and no error.

This affects loose-address import (including BIP47 / PayNym-derived addresses on `GET /wallet`). It does not apply to HD xpub gap scans, which do not use that filter. Default MyDojo (`local_bitcoind` / `local_indexer`) never loads this wrapper. The Esplora source is testnet `third_party_explorer` only; mainnet third-party uses OXT.

The change is `ntx += txids.length`, so the count matches unique txids, as in the bitcoind, local indexer, and OXT wrappers. Onion pairing, SOCKS, and the busy-address policy are unchanged; only the counter is corrected.

Existing `npm test` still passes (39). This wrapper has no dedicated unit tests.